### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+install:
+	@pip install --verbose .
+
+uninstall:
+	@pip -v uninstall kiss_slam
+
+editable:
+	@pip install scikit-build-core pyproject_metadata pathspec pybind11 ninja cmake
+	@pip install -ve .
+
+cpp:
+	@cmake -Bbuild .
+	@cmake --build build -j$(nproc --all)


### PR DESCRIPTION
The `Makefile` was not pushed for the initial release, probably because our `.gitignore` ignored it. This PR adds it to the repo.