### PR TITLE
Fix build from source 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ uninstall:
 
 editable:
 	@pip install scikit-build-core pyproject_metadata pathspec pybind11 ninja cmake
-	@pip install -ve .
+	@pip install --no-build-isolation -ve .
 
 cpp:
 	@cmake -Bbuild .

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ For development purposes:
 
 ```
 sudo apt install git python3-pip libeigen3-dev libsuitesparse-dev
+python3 -m pip install --upgrade pip
 git clone https://github.com/PRBonn/kiss-slam.git
 cd kiss-slam
 make editable


### PR DESCRIPTION
Based on https://github.com/PRBonn/kiss-slam/issues/11 and https://github.com/PRBonn/kiss-slam/issues/12, this PR updates the instructions and Makefile commands to build KISS-SLAM from source.