### PR TITLE
Make tools.cli executable

### DIFF
--- a/kiss_slam/tools/cli.py
+++ b/kiss_slam/tools/cli.py
@@ -157,3 +157,7 @@ def kiss_slam(
 
 def run():
     app()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
This small PR makes kiss_slam.tools.cli executable to enable running the entrypoint via `python -m kiss_slam.tools.cli`, which is a common way to set up a launch configuration in vscode to debug a python module.