### PR TITLE
Add API call for extracting only occupied voxels

### DIFF
--- a/kiss_slam/kiss_slam_pybind/kiss_slam_pybind.cpp
+++ b/kiss_slam/kiss_slam_pybind/kiss_slam_pybind.cpp
@@ -77,5 +77,6 @@ PYBIND11_MODULE(kiss_slam_pybind, m) {
     grid_mapper.def(py::init<float, float>(), "resolution"_a, "max_range"_a)
         .def("_integrate_frame", &OccupancyMapper::IntegrateFrame, "pointcloud"_a, "pose"_a)
         .def("_get_active_voxels", &OccupancyMapper::GetOccupancyInformation)
+        .def("_get_occupied_voxels", &OccupancyMapper::GetOccupiedVoxels, "probability_threshold"_a)
         .def("_save_occupancy_volume", &OccupancyMapper::SaveOccupancyVolume, "filename"_a);
 }

--- a/kiss_slam/kiss_slam_pybind/occupancy_mapper/occupancy_mapper.cpp
+++ b/kiss_slam/kiss_slam_pybind/occupancy_mapper/occupancy_mapper.cpp
@@ -35,6 +35,9 @@ static constexpr float logodds_occ = 2.1972f;
 inline float ProbabilityOccupied(const float logodds) {
     return 1.0f - (1.0f / (1.0f + std::exp(logodds)));
 }
+inline float LogOddsOccupied(const float probability) {
+    return std::log((1.0f / (1.0f - probability)) - 1.0f);
+}
 }  // namespace
 
 namespace occupancy_mapper {
@@ -69,15 +72,18 @@ std::tuple<Vector3iVector, std::vector<float>> OccupancyMapper::GetOccupancyInfo
     return std::make_tuple(voxel_indices, voxel_occupancies);
 }
 
-Vector3iVector OccupancyMapper::GetOccupiedVoxels(float probability_threshold) const {
+Vector3iVector OccupancyMapper::GetOccupiedVoxels(
+    const float occupancy_probability_threshold) const {
     Vector3iVector voxel_indices;
+    const float logodds_threshold = LogOddsOccupied(occupancy_probability_threshold);
     const auto num_of_active_voxels = map_.activeCellsCount();
     voxel_indices.reserve(num_of_active_voxels);
     map_.forEachCell([&](const float &logodds, const Bonxai::CoordT &voxel) {
-        if (ProbabilityOccupied(logodds) > probability_threshold) {
+        if (logodds > logodds_threshold) {
             voxel_indices.emplace_back(Bonxai::ConvertPoint<Eigen::Vector3i>(voxel));
         }
     });
+    voxel_indices.shrink_to_fit();
     return voxel_indices;
 }
 

--- a/kiss_slam/kiss_slam_pybind/occupancy_mapper/occupancy_mapper.cpp
+++ b/kiss_slam/kiss_slam_pybind/occupancy_mapper/occupancy_mapper.cpp
@@ -69,6 +69,18 @@ std::tuple<Vector3iVector, std::vector<float>> OccupancyMapper::GetOccupancyInfo
     return std::make_tuple(voxel_indices, voxel_occupancies);
 }
 
+Vector3iVector OccupancyMapper::GetOccupiedVoxels(float probability_threshold) const {
+    Vector3iVector voxel_indices;
+    const auto num_of_active_voxels = map_.activeCellsCount();
+    voxel_indices.reserve(num_of_active_voxels);
+    map_.forEachCell([&](const float &logodds, const Bonxai::CoordT &voxel) {
+        if (ProbabilityOccupied(logodds) > probability_threshold) {
+            voxel_indices.emplace_back(Bonxai::ConvertPoint<Eigen::Vector3i>(voxel));
+        }
+    });
+    return voxel_indices;
+}
+
 void OccupancyMapper::UpdateVoxelOccupancy(const Bonxai::CoordT &coord, const float value) {
     // tg exploit Vdb caching
     accessor_.setCellOn(coord, 0.0);

--- a/kiss_slam/kiss_slam_pybind/occupancy_mapper/occupancy_mapper.hpp
+++ b/kiss_slam/kiss_slam_pybind/occupancy_mapper/occupancy_mapper.hpp
@@ -40,6 +40,7 @@ public:
 
     void IntegrateFrame(const Vector3fVector &pointcloud, const Eigen::Matrix4f &pose);
     std::tuple<Vector3iVector, std::vector<float>> GetOccupancyInformation() const;
+    Vector3iVector GetOccupiedVoxels(float probability_threshold) const;
     void SaveOccupancyVolume(const std::string &filename) const {
         std::ofstream data(filename, std::ios::binary);
         Bonxai::Serialize(data, map_);

--- a/kiss_slam/kiss_slam_pybind/occupancy_mapper/occupancy_mapper.hpp
+++ b/kiss_slam/kiss_slam_pybind/occupancy_mapper/occupancy_mapper.hpp
@@ -40,7 +40,7 @@ public:
 
     void IntegrateFrame(const Vector3fVector &pointcloud, const Eigen::Matrix4f &pose);
     std::tuple<Vector3iVector, std::vector<float>> GetOccupancyInformation() const;
-    Vector3iVector GetOccupiedVoxels(float probability_threshold) const;
+    Vector3iVector GetOccupiedVoxels(const float occupancy_probability_threshold) const;
     void SaveOccupancyVolume(const std::string &filename) const {
         std::ofstream data(filename, std::ios::binary);
         Bonxai::Serialize(data, map_);

--- a/kiss_slam/occupancy_mapper.py
+++ b/kiss_slam/occupancy_mapper.py
@@ -50,11 +50,17 @@ class OccupancyGridMapper:
 
     def compute_3d_occupancy_information(self):
         active_voxels, occupancies = self.occupancy_mapping_pipeline._get_active_voxels()
-        self.active_voxels = np.asarray(active_voxels, int)
+        self.active_voxels = np.asarray(active_voxels, np.int32)
         self.occupancies = np.asarray(occupancies, float)
         self.occupied_voxels = self.active_voxels[
             np.where(self.occupancies > self.config.occupied_threshold)[0]
         ]
+
+    def compute_3d_only_occupied_voxels(self):
+        occupied_voxels = self.occupancy_mapping_pipeline._get_occupied_voxels(
+            self.config.occupied_threshold
+        )
+        self.occupied_voxels = np.asarray(occupied_voxels, np.int32)
 
     def compute_2d_occupancy_information(self):
         min_z_idx = int(self.config.z_min // self.config.resolution)

--- a/kiss_slam/occupancy_mapper.py
+++ b/kiss_slam/occupancy_mapper.py
@@ -56,7 +56,7 @@ class OccupancyGridMapper:
             np.where(self.occupancies > self.config.occupied_threshold)[0]
         ]
 
-    def compute_3d_only_occupied_voxels(self):
+    def compute_3d_occupied_voxels(self):
         occupied_voxels = self.occupancy_mapping_pipeline._get_occupied_voxels(
             self.config.occupied_threshold
         )


### PR DESCRIPTION
Just a quick PR based on the discussion in #26.

This PR adds `OccupancyMapper::GetOccupiedVoxels(float probability_threshold)` to the C++ API and binds it to `_get_occupied_voxels(probability_threshold)`. This provides a method for extracting only occupied voxels without the additional overhead of loading unoccupied voxels into Python.

This PR doesn't address the concern that @danielS91 raises about memory footprint in compute_3d_occupancy_information (per discussion there, it is sometimes desirable to track free-space information), but does provide an alternative method for use when memory is a concern.

Thoughts? I'm happy to take another swing at this.