### PR TITLE
Restrict click version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pydantic>=2",
     "tqdm",
     "pydantic-settings",
+    "click<=8.1", # TODO: Remove
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "pydantic>=2",
     "tqdm",
     "pydantic-settings",
-    "click==8.1.3", # TODO: Remove
+    "click<8.2", # TODO: Remove
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "pydantic>=2",
     "tqdm",
     "pydantic-settings",
-    "click<=8.1", # TODO: Remove
+    "click==8.1.3", # TODO: Remove
 ]
 
 [project.scripts]


### PR DESCRIPTION
Same as https://github.com/PRBonn/kiss-icp/pull/465

> The CI failed on KISS-SLAM, because typer depends on click for which version 8.2 got released two days ago. This version has some changes that break typer, see https://github.com/fastapi/typer/pull/1145.

> For now I explicitly added click as dependency and restricted the version. As soon as https://github.com/fastapi/typer/pull/1145 is merged, we can remove it again and rely on typer handling it.