### PR TITLE
Use latest map-closures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = [
     "kiss-icp>=1.2.3",
-    "map_closures>=2.0.1",
+    "map_closures>=2.0.2",
     "open3d>=0.19.0",
     "numpy",
     "PyYAML",


### PR DESCRIPTION
This PR enforces `map-closures` to be at least version 2.0.2, which fixes the issue described in https://github.com/PRBonn/kiss-slam/issues/30.