### PR TITLE
Update param to paper version for reproducibility

### DIFF
--- a/kiss_slam/kiss_slam_pybind/voxel_map/voxel_map.cpp
+++ b/kiss_slam/kiss_slam_pybind/voxel_map/voxel_map.cpp
@@ -38,7 +38,7 @@ inline Voxel ToVoxelCoordinates(const Eigen::Vector3f &point, const float voxel_
                  static_cast<int>(std::floor(point.z() / voxel_size)));
 }
 
-static constexpr unsigned int min_points_for_covariance_computation = 5;
+static constexpr unsigned int min_points_for_covariance_computation = 3;
 
 std::tuple<Eigen::Vector3f, Eigen::Vector3f> ComputeCentroidAndNormal(
     const voxel_map::VoxelBlock &coordinates) {


### PR DESCRIPTION
The minimum number of points per voxel in `voxel_map.cpp` required to `ComputeCentroidAndNormal` per voxel was accidentally modified to `5` after the paper submission instead of `3` using which the results in the paper were computed.

This PR reverts this change so that people can reproduce the results in the paper.