### PR TITLE
fix: add rosbags dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pydantic>=2",
     "tqdm",
     "pydantic-settings",
+    "rosbags<0.11",
 ]
 
 [project.scripts]


### PR DESCRIPTION
The current installation of kiss-slam will produce the error on runtime: 

`ImportError: rosbags library not installed, run "pip install -U rosbags"`

even if it is installed. This is due to `rosbags` latest version have already updated the API.

