### PR TITLE
New fields for occupancy grid exports

### DIFF
--- a/kiss_slam/config/config.py
+++ b/kiss_slam/config/config.py
@@ -62,6 +62,10 @@ class OccupancyMapperConfig(BaseModel):
     max_range: Optional[float] = None
     z_min: float = 0.1
     z_max: float = 0.5
+    export_2d_occupancy_grid: bool = True
+    export_3d_occupancy_ply: bool = True
+    export_3d_occupied_voxels_only: bool = False
+    export_3d_occupancy_boxai_volume: bool = True
 
 
 class PoseGraphOptimizerConfig(BaseModel):

--- a/kiss_slam/occupancy_mapper.py
+++ b/kiss_slam/occupancy_mapper.py
@@ -81,11 +81,13 @@ class OccupancyGridMapper:
         ] = self.occupancies[indices_in_range]
         self.occupancy_grid = 1.0 - np.max(occupancy_grid, 2)
 
-    def write_3d_occupancy_grid(self, output_dir):
+    def write_3d_occupancy_ply(self, output_dir):
         map_points = (0.5 + self.occupied_voxels) * self.config.resolution
         o3d_pcd = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(map_points))
         o3d_pcd.estimate_normals()
         o3d.io.write_point_cloud(os.path.join(output_dir, "occupancy_pcd.ply"), o3d_pcd)
+    
+    def write_3d_occupancy_boxai_volume(self, output_dir):
         self.occupancy_mapping_pipeline._save_occupancy_volume(
             os.path.join(output_dir, "occupancy_grid_bonxai.bin")
         )

--- a/kiss_slam/pipeline.py
+++ b/kiss_slam/pipeline.py
@@ -103,14 +103,21 @@ class SlamPipeline(OdometryPipeline):
                 occupancy_grid_mapper.integrate_frame(
                     deskewed_scan, ref_ground_alignment @ self.poses[idx - self._first]
                 )
-            occupancy_grid_mapper.compute_3d_occupancy_information()
-            occupancy_grid_mapper.compute_2d_occupancy_information()
             occupancy_dir = os.path.join(self.results_dir, "occupancy_grid")
-            os.makedirs(occupancy_dir, exist_ok=True)
-            occupancy_grid_mapper.write_3d_occupancy_grid(occupancy_dir)
-            occupancy_2d_map_dir = os.path.join(occupancy_dir, "map2d")
-            os.makedirs(occupancy_2d_map_dir, exist_ok=True)
-            occupancy_grid_mapper.write_2d_occupancy_grid(occupancy_2d_map_dir)
+            if self.slam_config.occupancy_mapper.export_3d_occupancy_ply:
+                if self.slam_config.occupancy_mapper.export_3d_occupied_voxels_only:
+                    occupancy_grid_mapper.compute_3d_occupied_voxels()
+                else:
+                    occupancy_grid_mapper.compute_3d_occupancy_information()
+                os.makedirs(occupancy_dir, exist_ok=True)
+                occupancy_grid_mapper.write_3d_occupancy_ply(occupancy_dir)
+            if self.slam_config.occupancy_mapper.export_3d_occupancy_boxai_volume:
+                occupancy_grid_mapper.write_3d_occupancy_boxai_volume(occupancy_dir)
+            if self.slam_config.occupancy_mapper.export_2d_occupancy_grid:
+                occupancy_grid_mapper.compute_2d_occupancy_information()
+                occupancy_2d_map_dir = os.path.join(occupancy_dir, "map2d")
+                os.makedirs(occupancy_2d_map_dir, exist_ok=True)
+                occupancy_grid_mapper.write_2d_occupancy_grid(occupancy_2d_map_dir)
 
     def _write_local_maps(self):
         local_maps_dir = os.path.join(self.results_dir, "local_maps")


### PR DESCRIPTION
We've been recently using kiss-slam for a project and have had experiences mirroring the concerns in #26 . Having seen the added API calls in #29 , I think it could be valuable to expose said API and a general choice of outputs for the occupancy mapper in the config. I've added 4 new toggles, of which 3 are for setting the exports and one to toggle between the full- or occupied-only ply.

Some things I am not sure about are:
- If there should be an early exit or error if none of the exports are selected
- I used the full instance attributes (`self.slam_config.occupancy_mapper.---`) instead of an alias because I didn't want to import `OccupancyMapperConfig` into pipeline.py

Please let me know if this is of any interest and any other feedback, as I am quite new to contributing to OSS.